### PR TITLE
Decrease source indent level after throwing an exception

### DIFF
--- a/src/main/kotlin/verysecuresystems/external/RemoteSystemProblem.kt
+++ b/src/main/kotlin/verysecuresystems/external/RemoteSystemProblem.kt
@@ -9,15 +9,18 @@ import org.http4k.lens.LensFailure
 
 fun <T> HttpHandler.perform(request: Request, responseLens: BodyLens<T>): T = this(request)
     .let {
+
         if (it.status.code > 399) {
             throw RemoteSystemProblem(request.uri.toString(), it.status)
-        } else {
-            try {
-                responseLens(it)
-            } catch(e: LensFailure) {
-                throw RemoteSystemProblem(request.uri.toString(), BAD_GATEWAY)
-            }
         }
+
+        try {
+            responseLens(it)
+
+        } catch(e: LensFailure) {
+            throw RemoteSystemProblem(request.uri.toString(), BAD_GATEWAY)
+        }
+
     }
 
 data class RemoteSystemProblem(val name: String, val status: Status) : Exception("$name returned $status")


### PR DESCRIPTION
Having less indentation usually increases readability <-> Nesting code usually decreases readability. It's better to have a flat, sequential list of actions instead.